### PR TITLE
Point-1988: critical alert codehaus jackson-mapper-asl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,18 +102,11 @@
         <scope>provided</scope>
       </dependency>
 
-      <!-- Jackson 1.x -->
-      <dependency>
-        <groupId>org.codehaus.jackson</groupId>
-        <artifactId>jackson-mapper-asl</artifactId>
-        <version>${jackson-version}</version>
-      </dependency>
-
       <!-- Jackson 2.x -->
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>${jackson2-version}</version>
+        <version>${jackson-version}</version>
       </dependency>
 
       <!-- Markdown -->
@@ -468,8 +461,7 @@
   <properties>
     <!-- Encoding UTF-8 -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jackson2-version>2.12.7.1</jackson2-version>
-    <jackson-version>1.9.12</jackson-version>
+    <jackson-version>2.16.0</jackson-version>
     <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ssa</maven.build.timestamp.format>
     <timestamp>${maven.build.timestamp}</timestamp>
   </properties>


### PR DESCRIPTION
remove codehaus mapper because it's part of jackson-databind and critical alert
CVE: https://github.com/pitchpoint-solutions/handlebars.java/security/dependabot/85, https://github.com/pitchpoint-solutions/handlebars.java/security/dependabot/6